### PR TITLE
Add FastAPI backend for exercise data

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+EXCEL_PATH = BASE_DIR / 'Ejercicios-base.xlsx'
+IMG_DIR = BASE_DIR / 'img'
+
+_df = None
+
+def load_data():
+    global _df
+    if _df is None:
+        _df = pd.read_excel(EXCEL_PATH)
+    return _df
+
+def get_exercises():
+    df = load_data()
+    return df.to_dict(orient='records')
+
+def get_exercise_by_id(ex_id: str):
+    df = load_data()
+    result = df[df['ID'] == ex_id]
+    if result.empty:
+        return None
+    return result.iloc[0].to_dict()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from . import db
+
+app = FastAPI(title='GymApp')
+
+# Mount images folder
+app.mount('/img', StaticFiles(directory=db.IMG_DIR), name='img')
+
+@app.get('/exercises')
+def list_exercises():
+    """Return all exercises."""
+    return db.get_exercises()
+
+@app.get('/exercises/{ex_id}')
+def exercise_detail(ex_id: str):
+    ex = db.get_exercise_by_id(ex_id)
+    if not ex:
+        raise HTTPException(status_code=404, detail='Exercise not found')
+    return ex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- build simple FastAPI app
- load exercises from the Excel file
- expose endpoints to list all exercises and get details by ID
- serve images via static files
- add requirements list

## Testing
- `pip install -r requirements.txt`
- `python -m uvicorn app.main:app --port 8000 --reload`

------
https://chatgpt.com/codex/tasks/task_e_6857231bad348330a48ab494009c25b7