### PR TITLE
Add simple HTML homepage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from . import db
 
@@ -6,6 +7,28 @@ app = FastAPI(title='GymApp')
 
 # Mount images folder
 app.mount('/img', StaticFiles(directory=db.IMG_DIR), name='img')
+
+
+@app.get('/', response_class=HTMLResponse)
+def read_root():
+    """Homepage with basic links and example exercises."""
+    exercises = db.get_exercises()[:5]
+    items = ''.join(f"<li>{ex['Nombre (ES)']}</li>" for ex in exercises)
+    html_content = f"""
+    <html>
+        <head>
+            <title>GymApp</title>
+        </head>
+        <body>
+            <h1>Bienvenido a GymApp</h1>
+            <p><a href='/exercises'>Ver ejercicios</a></p>
+            <p><a href='/docs'>Documentación de la API</a></p>
+            <h2>Algunos ejercicios</h2>
+            <ul>{items}</ul>
+        </body>
+    </html>
+    """
+    return HTMLResponse(content=html_content)
 
 @app.get('/exercises')
 def list_exercises():


### PR DESCRIPTION
## Summary
- add `/` endpoint returning HTML greeting
- showcase a few exercises and link to the docs

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `python - <<'PY'
from fastapi.testclient import TestClient
from app.main import app
client = TestClient(app)
print('root', client.get('/').status_code)
print('exercises', len(client.get('/exercises').json()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68572889d9b0833096bcffde253a021c