### PR TITLE
Add design index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ uvicorn app.main:app
 ```
 
 The API will be available at `http://127.0.0.1:8000` by default.
+
+Visita la raíz (`/`) para consultar el **Lienzo de Diseño** que describe la estructura de la aplicación y la base de datos.

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from . import db
 
 app = FastAPI(title='GymApp')
@@ -8,26 +9,14 @@ app = FastAPI(title='GymApp')
 # Mount images folder
 app.mount('/img', StaticFiles(directory=db.IMG_DIR), name='img')
 
+# Path al template de la página principal
+INDEX_TEMPLATE = Path(__file__).resolve().parent / 'templates' / 'index.html'
+
 
 @app.get('/', response_class=HTMLResponse)
 def read_root():
-    """Homepage with basic links and example exercises."""
-    exercises = db.get_exercises()[:5]
-    items = ''.join(f"<li>{ex['Nombre (ES)']}</li>" for ex in exercises)
-    html_content = f"""
-    <html>
-        <head>
-            <title>GymApp</title>
-        </head>
-        <body>
-            <h1>Bienvenido a GymApp</h1>
-            <p><a href='/exercises'>Ver ejercicios</a></p>
-            <p><a href='/docs'>Documentación de la API</a></p>
-            <h2>Algunos ejercicios</h2>
-            <ul>{items}</ul>
-        </body>
-    </html>
-    """
+    """Retorna la página principal con el lienzo de diseño."""
+    html_content = INDEX_TEMPLATE.read_text(encoding='utf-8')
     return HTMLResponse(content=html_content)
 
 @app.get('/exercises')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>GymApp - Lienzo de Diseño</title>
+</head>
+<body>
+    <h1>GymApp - App de Rutinas de Gimnasio</h1>
+    <p>Este documento resume las características principales de la aplicación de rutinas y la base de datos integrada.</p>
+
+    <h2>1. Propósito General</h2>
+    <p>Desarrollar una aplicación que centralice una base de datos exhaustiva de ejercicios de musculación y fitness, integrando rutinas, seguimiento y visualización de imágenes anatómicas. El sistema debe permitir personalización y adaptarse a distintos objetivos.</p>
+    <ul>
+        <li>Registro de usuario y perfil físico con datos opcionales como edad, peso y objetivos.</li>
+        <li>Los datos se usan para adaptar rutinas, análisis y recomendaciones.</li>
+    </ul>
+
+    <h2>2. Estructura de la Base de Datos (Excel)</h2>
+    <p><strong>Archivo fuente:</strong> <code>BD_Ejercicios_mejorada_v8.xlsx</code></p>
+    <p>Columnas principales:</p>
+    <ul>
+        <li><strong>ID:</strong> Identificador único (ej. EX0001)</li>
+        <li><strong>Nombre (ES):</strong> Nombre en español</li>
+        <li><strong>Nombre (EN):</strong> Nombre en inglés</li>
+        <li><strong>Zona principal:</strong> Músculo o grupo muscular principal</li>
+        <li><strong>Músculos secundarios:</strong> Otros músculos involucrados</li>
+        <li><strong>Detalle/Descripción:</strong> Guía técnica y consejos de ejecución</li>
+        <li><strong>Imagen:</strong> Ruta del archivo (ej. <code>/img/EX0001.jpg</code>)</li>
+    </ul>
+
+    <h2>3. Gestión de Imágenes</h2>
+    <ul>
+        <li>Cada ejercicio cuenta con una imagen anatómica representativa ubicada en <code>/img/</code>.</li>
+        <li>Formato de nombre: <code>[ID].jpg</code> con tamaño estándar de 124 x 124 px.</li>
+    </ul>
+
+    <h2>4. Estructura y Funcionalidad de la App</h2>
+    <h3>a. Backend</h3>
+    <ul>
+        <li>Lectura de la base Excel y consultas filtradas.</li>
+        <li>Gestión de rutinas personalizadas y registro de progresos.</li>
+    </ul>
+    <h3>b. Frontend</h3>
+    <ul>
+        <li>Visualización de ejercicios y filtros por zona muscular, equipo o nivel.</li>
+        <li>Calendario de entrenamientos y carga rápida de progresos.</li>
+    </ul>
+    <h3>c. Funcionalidades Clave</h3>
+    <ul>
+        <li>Buscador de ejercicios.</li>
+        <li>Generador de rutina automática según objetivo y nivel.</li>
+        <li>Historial de seguimiento y análisis mensual.</li>
+    </ul>
+
+    <h2>5. Reglas y Buenas Prácticas</h2>
+    <ul>
+        <li>ID único e inalterable para cada ejercicio.</li>
+        <li>Actualización centralizada en el Excel.</li>
+        <li>Backup antes de cambios estructurales.</li>
+        <li>Esquema preparado para futuros campos opcionales.</li>
+    </ul>
+
+    <h2>6. Flujo de Trabajo Sugerido</h2>
+    <ol>
+        <li>Carga y revisión del Excel.</li>
+        <li>Mapeo de columnas y sincronización de imágenes.</li>
+        <li>Desarrollo del frontend y pruebas.</li>
+        <li>Iteración y mejoras continuas.</li>
+    </ol>
+
+    <h2>7. Observaciones Finales</h2>
+    <ul>
+        <li>El Excel es el núcleo del sistema.</li>
+        <li>Las imágenes deben estar correctamente nombradas y ubicadas.</li>
+        <li>El diseño facilita la consulta y el mantenimiento de la base de datos.</li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show design blueprint in new index page
- serve the index page from the root route
- mention the design page in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572eed537c8330bec7ee17630b7e12