### PR TITLE
Update Vite config base path

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+// ¡IMPORTANTE! Esto es para deploy en GitHub Pages en /gymapp/
 export default defineConfig({
   plugins: [react()],
-  base: '/static/',
+  base: '/gymapp/',
 })


### PR DESCRIPTION
## Summary
- set vite `base` to `/gymapp/` for GitHub Pages deployment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859f56ce4808330a77e0cc5c5e0f655