### PR TITLE
Update App to render Landing only

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,8 @@
+
+import Landing from "./Landing";
+
 function App() {
-  return (
-    <div style={{
-      minHeight: '100vh',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      background: '#F5F5F5',
-      flexDirection: 'column'
-    }}>
-      <h1 style={{ color: '#800020', fontSize: '2.2rem' }}>ENTRENAPP</h1>
-      <p style={{ color: '#555', fontSize: '1.1rem' }}>Landing funcional - prueba de deploy</p>
-    </div>
-  );
+  return <Landing />;
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- render the `Landing` component directly from `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859fd1f552083308af6fa78c3138161