### PR TITLE
Add ExerciseCard component

### DIFF
--- a/src/components/ExerciseCard.module.css
+++ b/src/components/ExerciseCard.module.css
@@ -1,0 +1,9 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  padding: .75rem;
+  border-radius: 1rem;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,.08);
+}

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -1,0 +1,22 @@
+export interface Exercise {
+  id: string;
+  nombre: string;
+  zonaPrincipal: string;
+}
+
+export type Props = {
+  exercise: Exercise;
+  onSelect: (e: Exercise) => void;
+};
+
+import styles from "./ExerciseCard.module.css";
+
+export default function ExerciseCard({ exercise, onSelect }: Props) {
+  return (
+    <button onClick={() => onSelect(exercise)} className={styles.card}>
+      <img src={`/img/${exercise.id}.jpg`} alt={exercise.nombre} />
+      <h3>{exercise.nombre}</h3>
+      <small>{exercise.zonaPrincipal}</small>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ExerciseCard` component for selecting exercises
- include module CSS for shadowed card styling
- run `npm install` and `npm run build` to ensure client builds

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b06de045883309efe3631b12ec963