### PR TITLE
Add Home page with grid

### DIFF
--- a/src/data/exercises.json
+++ b/src/data/exercises.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "EX0001",
+    "nombre": "Dominadas",
+    "zonaPrincipal": "Espalda"
+  },
+  {
+    "id": "EX0002",
+    "nombre": "Biceps con agarre supino",
+    "zonaPrincipal": "Bíceps"
+  },
+  {
+    "id": "EX0003",
+    "nombre": "Dominada Horizontal",
+    "zonaPrincipal": "Espalda"
+  },
+  {
+    "id": "EX0004",
+    "nombre": "Dominada Bombero",
+    "zonaPrincipal": "Espalda"
+  }
+]

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import data from "../data/exercises.json"; // temporal
+import ExerciseCard, { Exercise } from "../components/ExerciseCard";
+import SearchBar from "../components/SearchBar";
+
+export default function Home() {
+  const [query, setQuery] = useState("");
+  const filtered = data.filter((e: Exercise) =>
+    e.nombre.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <main style={{ padding: "1rem" }}>
+      <SearchBar onSearch={setQuery} />
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill,minmax(140px,1fr))",
+          gap: "1rem",
+          marginTop: "1rem",
+        }}
+      >
+        {filtered.map((ex: Exercise) => (
+          <ExerciseCard
+            key={ex.id}
+            exercise={ex}
+            onSelect={() => {
+              /* navigate al detalle */
+            }}
+          />
+        ))}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a sample dataset under `src/data`
- implement new Home page with responsive grid using SearchBar and ExerciseCard

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b0aac0f7883308d5da7ade0f72a06