### PR TITLE
Add skeleton loader to ExerciseCard

### DIFF
--- a/src/components/ExerciseCard.module.css
+++ b/src/components/ExerciseCard.module.css
@@ -7,3 +7,20 @@
   background: #fff;
   box-shadow: 0 2px 6px rgba(0,0,0,.08);
 }
+
+.skeleton {
+  width: 100%;
+  padding-top: 100%;
+  background: linear-gradient(90deg, #eee 25%, #f5f5f5 50%, #eee 75%);
+  background-size: 200% 100%;
+  animation: pulse 1.2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -10,11 +10,20 @@ export type Props = {
 };
 
 import styles from "./ExerciseCard.module.css";
+import { useState } from "react";
 
 export default function ExerciseCard({ exercise, onSelect }: Props) {
+  const [loaded, setLoaded] = useState(false);
   return (
     <button onClick={() => onSelect(exercise)} className={styles.card}>
-      <img src={`/img/${exercise.id}.jpg`} alt={exercise.nombre} />
+      <div style={{ position: "relative" }}>
+        {!loaded && <div className={styles.skeleton} />}
+        <img
+          src={`/img/${exercise.id}.jpg`}
+          alt={exercise.nombre}
+          onLoad={() => setLoaded(true)}
+        />
+      </div>
       <h3>{exercise.nombre}</h3>
       <small>{exercise.zonaPrincipal}</small>
     </button>


### PR DESCRIPTION
## Summary
- implement a simple skeleton loader for `ExerciseCard`
- style the skeleton animation

## Testing
- `npm run lint` within client
- `npm run build` within client

------
https://chatgpt.com/codex/tasks/task_e_685b10e566f48330a8dd6fc6359f3917