### PR TITLE
Add ExerciseContext provider

### DIFF
--- a/src/context/ExerciseContext.tsx
+++ b/src/context/ExerciseContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import data from "../data/exercises.json";
+
+export type Exercise = typeof data[number];
+
+export type Ctx = {
+  exercises: Exercise[];
+  selected: Exercise[];
+  toggle: (id: string) => void;
+};
+
+const ExerciseContext = createContext<Ctx>(null!);
+
+export function ExerciseProvider({ children }: { children: ReactNode }) {
+  const [selected, setSel] = useState<Exercise[]>([]);
+  const toggle = (id: string) =>
+    setSel(s =>
+      s.some(e => e.id === id)
+        ? s.filter(e => e.id !== id)
+        : [...s, data.find(e => e.id === id)!]
+    );
+
+  return (
+    <ExerciseContext.Provider value={{ exercises: data, selected, toggle }}>
+      {children}
+    </ExerciseContext.Provider>
+  );
+}
+
+export const useExercises = () => useContext(ExerciseContext);


### PR DESCRIPTION
## Summary
- create `src/context` folder
- implement `ExerciseContext` for toggling selected exercises

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b367cf6788330b20eeeba913beabc