### PR TITLE
Refactor ExerciseCard to use context

### DIFF
--- a/src/components/ExerciseCard.module.css
+++ b/src/components/ExerciseCard.module.css
@@ -8,6 +8,10 @@
   box-shadow: 0 2px 6px rgba(0,0,0,.08);
 }
 
+.active {
+  outline: 3px solid var(--color-primary);
+}
+
 .skeleton {
   width: 100%;
   padding-top: 100%;

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -1,21 +1,17 @@
-export interface Exercise {
-  id: string;
-  nombre: string;
-  zonaPrincipal: string;
-}
-
-export type Props = {
-  exercise: Exercise;
-  onSelect: (e: Exercise) => void;
-};
+import { Exercise, useExercises } from "../context/ExerciseContext";
 
 import styles from "./ExerciseCard.module.css";
 import { useState } from "react";
 
-export default function ExerciseCard({ exercise, onSelect }: Props) {
+export default function ExerciseCard({ exercise }: { exercise: Exercise }) {
+  const { toggle, selected } = useExercises();
   const [loaded, setLoaded] = useState(false);
+  const isSel = selected.some(e => e.id === exercise.id);
   return (
-    <button onClick={() => onSelect(exercise)} className={styles.card}>
+    <button
+      onClick={() => toggle(exercise.id)}
+      className={`${styles.card} ${isSel ? styles.active : ""}`}
+    >
       <div style={{ position: "relative" }}>
         {!loaded && <div className={styles.skeleton} />}
         <img

--- a/src/pages/ExerciseDetail.tsx
+++ b/src/pages/ExerciseDetail.tsx
@@ -1,11 +1,11 @@
 import { useParams, useNavigate } from "react-router-dom";
-import data from "../data/exercises.json";
-import { Exercise } from "../components/ExerciseCard";
+import { Exercise, useExercises } from "../context/ExerciseContext";
 
 export default function ExerciseDetail() {
   const { id } = useParams();
   const nav = useNavigate();
-  const ex = data.find((e: Exercise) => e.id === id);
+  const { exercises } = useExercises();
+  const ex = exercises.find((e: Exercise) => e.id === id);
 
   if (!ex) return <p>No encontrado</p>;
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import data from "../data/exercises.json"; // temporal
-import ExerciseCard, { Exercise } from "../components/ExerciseCard";
+import ExerciseCard from "../components/ExerciseCard";
+import { Exercise, useExercises } from "../context/ExerciseContext";
 import SearchBar from "../components/SearchBar";
 
 export default function Home() {
+  const { exercises } = useExercises();
   const [query, setQuery] = useState("");
-  const filtered = data.filter((e: Exercise) =>
+  const filtered = exercises.filter((e: Exercise) =>
     e.nombre.toLowerCase().includes(query.toLowerCase())
   );
 
@@ -24,9 +25,6 @@ export default function Home() {
           <ExerciseCard
             key={ex.id}
             exercise={ex}
-            onSelect={() => {
-              /* navigate al detalle */
-            }}
           />
         ))}
       </section>


### PR DESCRIPTION
## Summary
- update ExerciseCard to toggle selection with ExerciseContext
- highlight active card via CSS
- adjust Home page to read exercises from context
- use context in ExerciseDetail

## Testing
- `python -m py_compile app/*.py`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b38fefe548330a4ed934fdedc8fb2