### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy Vite → GitHub Pages
+on:
+  push:
+    branches: [main]
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci --ignore-scripts
+        working-directory: client
+      - run: npm run build --if-present
+        working-directory: client
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client/dist
+          cname: ""


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy the Vite frontend to GitHub Pages

## Testing
- `npm run lint` within `client`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685b6855e1cc83309e27541d0cfd18be