### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Build & Deploy GymApp
+on:
+  push:
+    branches: [main]
+permissions:
+    contents: write
+    pages: write
+    id-token: write
+concurrency:
+    group: pages
+    cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci --ignore-scripts
+        working-directory: client
+      - run: npm run build --if-present
+        working-directory: client
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./client/dist
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- add GH Pages workflow to build React app from `client/`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b6cc7983c8330bbff69435f831c5e