### PR TITLE
Add Firebase setup and auth hook

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import { auth, login, logout } from '../services/firebase'
+import { onAuthStateChanged, User } from 'firebase/auth'
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(auth.currentUser)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, setUser)
+    return unsub
+  }, [])
+
+  return { user, login, logout }
+}

--- a/client/src/services/firebase.ts
+++ b/client/src/services/firebase.ts
@@ -1,0 +1,10 @@
+import { initializeApp } from 'firebase/app'
+import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
+import { firebaseConfig } from '../config/firebaseConfig'
+
+const app = initializeApp(firebaseConfig)
+export const auth = getAuth(app)
+export const db = getFirestore(app)
+export const login = () => signInWithPopup(auth, new GoogleAuthProvider())
+export const logout = () => signOut(auth)

--- a/client/src/services/workout.ts
+++ b/client/src/services/workout.ts
@@ -1,0 +1,15 @@
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
+import { db } from './firebase'
+
+export interface Workout {
+  userId: string
+  exercises: string[]
+  notes?: string
+}
+
+export async function logWorkout(data: Workout) {
+  await addDoc(collection(db, 'workouts'), {
+    ...data,
+    createdAt: serverTimestamp(),
+  })
+}


### PR DESCRIPTION
## Summary
- initialize Firebase app in new service
- add useAuth hook to manage Firebase authentication state
- provide basic workout logging service

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863383518d883309dda2c6a2c73c50e