### PR TITLE
Set Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+export default defineConfig({
+ base: "/gymapp/", // 👈 importante!
+ plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add a `vite.config.ts` with the base path `/gymapp/` so built assets work on GitHub Pages

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68633cc7ce6883309352e05493cbc3f9