### PR TITLE
Add Exercises page with PR placeholder

### DIFF
--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -1,11 +1,17 @@
 import { Exercise, useExercises } from "../context/ExerciseContext";
 
 import styles from "./ExerciseCard.module.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { getPR } from "../services/workout";
 
 export default function ExerciseCard({ exercise }: { exercise: Exercise }) {
   const { toggle, selected } = useExercises();
   const [loaded, setLoaded] = useState(false);
+  const [pr, setPr] = useState<number | null>(null);
+
+  useEffect(() => {
+    getPR(exercise.id).then(setPr);
+  }, [exercise.id]);
   const isSel = selected.some(e => e.id === exercise.id);
   return (
     <button
@@ -22,6 +28,7 @@ export default function ExerciseCard({ exercise }: { exercise: Exercise }) {
       </div>
       <h3>{exercise.nombre}</h3>
       <small>{exercise.zonaPrincipal}</small>
+      <small>PR: {pr === null ? "-" : `${pr} kg`}</small>
     </button>
   );
 }

--- a/src/pages/ExercisesPage.tsx
+++ b/src/pages/ExercisesPage.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import ExerciseCard from "../components/ExerciseCard";
+import SearchBar from "../components/SearchBar";
+import { useExercises, Exercise } from "../context/ExerciseContext";
+
+export default function ExercisesPage() {
+  const { exercises } = useExercises();
+  const [query, setQuery] = useState("");
+  const filtered = exercises.filter((e: Exercise) =>
+    e.nombre.toLowerCase().includes(query.toLowerCase())
+  );
+  return (
+    <main style={{ padding: "1rem" }}>
+      <SearchBar onSearch={setQuery} />
+      <section className="grid" style={{ marginTop: "1rem" }}>
+        {filtered.map(ex => (
+          <ExerciseCard key={ex.id} exercise={ex} />
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,8 @@
+export default function HistoryPage() {
+  return (
+    <main style={{ padding: "1rem" }}>
+      <h2>Historial</h2>
+      <p>Próximamente se listarán tus entrenamientos.</p>
+    </main>
+  );
+}

--- a/src/services/workout.ts
+++ b/src/services/workout.ts
@@ -1,0 +1,4 @@
+export async function getPR(exerciseId: string): Promise<number> {
+  // TODO: fetch from backend or database
+  return 0;
+}


### PR DESCRIPTION
## Summary
- create placeholder workout service and show PR in `ExerciseCard`
- add `ExercisesPage` to list exercises with search and cards
- add `HistoryPage` placeholder

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module '../config/firebaseConfig')*

------
https://chatgpt.com/codex/tasks/task_e_68634048d540833096a6e67cf172df3a