### PR TITLE
Add basic GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,24 @@
-name: Deploy Vite → GitHub Pages
+name: deploy-gh-pages
 on:
-  push:
-    branches: [main]
+ push:
+ branches: [main]
+permissions: { contents: write }
 jobs:
-  build-deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm ci --ignore-scripts
-        working-directory: client
-      - run: npm run build --if-present
-        working-directory: client
-      - uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./client/dist
-          cname: ""
+ build:
+ runs-on: ubuntu-latest
+ steps:
+ - uses: actions/checkout@v4
+ - uses: actions/setup-node@v4
+ with: { node-version: 20 }
+ - run: npm ci
+ - run: npm run build --if-present
+ - uses: actions/upload-pages-artifact@v3
+ with: { path: dist }
+ deploy:
+ needs: build
+ runs-on: ubuntu-latest
+ environment:
+ name: github-pages
+ url: ${{ steps.deployment.outputs.page_url }}
+ steps:
+ - uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- build on pushes to `main`
- deploy the `dist` directory to GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68634303b7088330b7562b532297669b