### PR TITLE
Add LandingPage component with simple styling

### DIFF
--- a/src/landing.css
+++ b/src/landing.css
@@ -1,0 +1,4 @@
+.landing{height:100vh;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;gap:1.5rem}
+.landing h1{color:#800020;font-size:2.5rem;margin:0}
+.landing p{color:#555;margin:0}
+.landing .btn{background:#800020;color:#fff;padding:.75rem 2.5rem;border-radius:4px;text-decoration:none;font-weight:600;}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,12 @@
+import { Link } from "react-router-dom";
+import "../landing.css";
+
+export default function LandingPage() {
+ return (
+ <div className="landing">
+ <h1>ENTRENAPP</h1>
+ <p>Entrená como querés, donde querés.</p>
+ <Link to="/ejercicios" className="btn">COMENZAR</Link>
+ </div>
+ );
+}


### PR DESCRIPTION
## Summary
- add `LandingPage` component linking to `/ejercicios`
- add dedicated landing page styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868834f31508330a5cda052f71ff64f