### PR TITLE
Update router to include LandingPage and exercises path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, NavLink } from "react-router-dom";
+import LandingPage from "./pages/LandingPage";
 import ExercisesPage from "./pages/ExercisesPage";
 import HistoryPage from "./pages/HistoryPage";
 import "./App.css";
@@ -7,11 +8,12 @@ export default function App() {
   return (
     <BrowserRouter basename="/gymapp">
       <nav className="nav">
-        <NavLink to="/" end>Ejercicios</NavLink>
+        <NavLink to="/ejercicios">Ejercicios</NavLink>
         <NavLink to="/historial">Historial</NavLink>
       </nav>
       <Routes>
-        <Route path="/" element={<ExercisesPage/>} />
+        <Route path="/" element={<LandingPage/>} />
+        <Route path="/ejercicios" element={<ExercisesPage/>} />
         <Route path="/historial" element={<HistoryPage/>} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- add landing page route and nav links for `/ejercicios` and `/historial`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686883ed5f7c833085f5afcd12754ea6