### PR TITLE
Improve onboarding flow wiring and harden client state handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,12 @@
-import Landing from "./Landing";
+import OnboardingRouter from './components/Onboarding/OnboardingRouter'
+import { UserProvider } from './hooks/useUser'
 
 function App() {
-  return <Landing />;
+  return (
+    <UserProvider>
+      <OnboardingRouter />
+    </UserProvider>
+  )
 }
 
-export default App;
+export default App

--- a/client/src/Landing.tsx
+++ b/client/src/Landing.tsx
@@ -1,4 +1,8 @@
+import { useNavigate } from 'react-router-dom'
+
 function Landing() {
+  const navigate = useNavigate()
+
   return (
     <div
       style={{
@@ -16,6 +20,7 @@ function Landing() {
         Entrená como querés, donde querés.
       </p>
       <button
+        onClick={() => navigate('/step1')}
         style={{
           backgroundColor: '#800020',
           color: '#fff',
@@ -23,6 +28,7 @@ function Landing() {
           borderRadius: '4px',
           padding: '0.9rem 2rem',
           fontSize: '1.1rem',
+          cursor: 'pointer',
         }}
       >
         COMENZAR

--- a/client/src/components/Exercises/ExerciseList.tsx
+++ b/client/src/components/Exercises/ExerciseList.tsx
@@ -79,13 +79,7 @@ export default function ExerciseList() {
         {filtered.map(ex => (
           <div key={ex.ID} className="card" onClick={()=>setDetail(ex)} style={{padding:'1rem',cursor:'pointer'}}>
             <ImageWithFallback src={ex.Imagen} alt={ex["Nombre (ES)"]} />
-            <h3
-              dangerouslySetInnerHTML={{
-                __html: search
-                  ? ex["Nombre (ES)"].replace(new RegExp(`(${search})`, 'ig'), '<u>$1</u>')
-                  : ex["Nombre (ES)"]
-              }}
-            />
+            <h3>{highlightMatch(ex["Nombre (ES)"], search)}</h3>
             <p>{ex["Zona principal"]}</p>
           </div>
         ))}
@@ -131,4 +125,20 @@ function ImageWithFallback({src, alt}: ImgProps) {
       />
     </div>
   )
+}
+
+
+function highlightMatch(text: string, query: string) {
+  if (!query.trim()) return text
+
+  const normalizedQuery = query.trim().toLowerCase()
+  const parts = text.split(new RegExp(`(${escapeRegExp(normalizedQuery)})`, 'ig'))
+
+  return parts.map((part, index) =>
+    part.toLowerCase() === normalizedQuery ? <u key={`${part}-${index}`}>{part}</u> : part
+  )
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/client/src/components/Onboarding/OnboardingRouter.tsx
+++ b/client/src/components/Onboarding/OnboardingRouter.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
+import Landing from '../../Landing'
 import Step1 from './Step1'
 import Step2 from './Step2'
 import ProfilePage from '../Profile/ProfilePage'
@@ -9,7 +10,8 @@ export default function OnboardingRouter() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Step1 />} />
+        <Route path="/" element={<Landing />} />
+        <Route path="/step1" element={<Step1 />} />
         <Route path="/step2" element={<Step2 />} />
         <Route path="/perfil" element={<ProfilePage />} />
         <Route path="/calendario" element={<CalendarPage />} />

--- a/client/src/components/Onboarding/Step2.tsx
+++ b/client/src/components/Onboarding/Step2.tsx
@@ -29,7 +29,7 @@ export default function Step2() {
   const { setUserData, finalizeUser } = useUser()
 
   const onSubmit = async (data: Step2Data) => {
-    setUserData({
+    const payload = {
       equipo: data.equipo,
       lesiones: data.lesiones,
       medidas: data.medidas,
@@ -37,8 +37,10 @@ export default function Step2() {
         pesoMensual: data.notificaciones?.pesoMensual ?? false,
         diarioSesion: data.notificaciones?.diarioSesion ?? false,
       },
-    })
-    await finalizeUser()
+    }
+
+    setUserData(payload)
+    await finalizeUser(payload)
     navigate('/perfil')
   }
 

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -1,12 +1,12 @@
-import React, { createContext, useContext, useState } from 'react'
-import type { ReactNode } from "react"
+import { createContext, createElement, useContext, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
 import type { User } from '../models/user'
 import { saveUser, loadUser } from '../services/api'
 
 interface UserContextValue {
   user: User | null
-  setUserData: (data: Partial<User>) => void
-  finalizeUser: () => Promise<void>
+  setUserData: (data: Partial<User>) => Partial<User>
+  finalizeUser: (data?: Partial<User>) => Promise<void>
 }
 
 const UserContext = createContext<UserContextValue | undefined>(undefined)
@@ -15,22 +15,24 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
 
   const setUserData = (data: Partial<User>) => {
-    setUser(prev => ({ ...(prev || ({} as User)), ...data } as User))
+    setUser((prev) => ({ ...(prev || ({} as User)), ...data } as User))
+    return data
   }
 
-  const finalizeUser = async () => {
-    if (user) {
-      const saved = await saveUser(user)
+  const finalizeUser = async (data?: Partial<User>) => {
+    const payload = data ? { ...(user || {}), ...data } : user
+
+    if (payload) {
+      const saved = await saveUser(payload)
       setUser(saved)
     }
   }
 
-  // load from localStorage on mount
-  useState(() => {
-    loadUser().then(u => u && setUser(u))
-  })
+  useEffect(() => {
+    loadUser().then((u) => u && setUser(u))
+  }, [])
 
-  return React.createElement(
+  return createElement(
     UserContext.Provider,
     { value: { user, setUserData, finalizeUser } },
     children


### PR DESCRIPTION
### Motivation
- Hacer que la aplicación arranque con el proveedor de usuario y el enrutador de onboarding para habilitar el flujo completo de onboarding/ perfil en vez de quedarse en una landing estática.
- Evitar escrituras con estado desactualizado al persistir usuario desde el segundo paso del onboarding.
- Reemplazar uso inseguro de `dangerouslySetInnerHTML` al resaltar nombres de ejercicios para prevenir inyección accidental y mejorar robustez.

### Description
- Cambia el root de la app para envolver la interfaz con `UserProvider` y renderizar `OnboardingRouter` desde `App` para habilitar las rutas de onboarding y perfil.
- Actualiza `Landing` para navegar a `/step1` al pulsar el CTA `COMENZAR` y ajusta `OnboardingRouter` para exponer `/` (landing) y `/step1` (paso 1).
- Refactoriza `useUser` para usar `useEffect` al cargar el usuario desde `localStorage`, permite pasar un `payload` a `finalizeUser` y hace que `setUserData` devuelva el dato aplicado para evitar condiciones de carrera con estado stale.
- Modifica `Step2` para construir un único `payload` y pasar ese mismo objeto tanto a `setUserData` como a `finalizeUser(payload)` asegurando que se persista exactamente lo enviado en el formulario.
- Reemplaza `dangerouslySetInnerHTML` en `ExerciseList` por una función `highlightMatch` que hace el resaltado de búsqueda con JSX y una función `escapeRegExp`, eliminando HTML inyectado.

### Testing
- Ejecuté `npm --prefix client run lint` y la verificación de ESLint pasó satisfactoriamente.
- Ejecuté `npm --prefix client run build` y la app se compiló correctamente con Vite (nota: advertencia de tamaño de chunk principal >500 kB, no bloqueante).
- Levanté el servidor de desarrollo y capturé una captura de pantalla con Playwright para validar visualmente la landing y la navegación inicial; la captura se generó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c5f810e483309405a2b7ab0cf0da)