### PR TITLE
Fix legacy server path resolution for exercise data and frontend build

### DIFF
--- a/server_legacy/app/db.py
+++ b/server_legacy/app/db.py
@@ -1,9 +1,25 @@
 import pandas as pd
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent
-EXCEL_PATH = BASE_DIR / 'Ejercicios-base.xlsx'
-IMG_DIR = BASE_DIR / 'img'
+SERVER_DIR = Path(__file__).resolve().parent.parent
+REPO_DIR = SERVER_DIR.parent
+
+
+def _first_existing_path(*paths: Path) -> Path:
+    for candidate in paths:
+        if candidate.exists():
+            return candidate
+    return paths[0]
+
+
+EXCEL_PATH = _first_existing_path(
+    REPO_DIR / 'Ejercicios-base.xlsx',
+    SERVER_DIR / 'Ejercicios-base.xlsx',
+)
+IMG_DIR = _first_existing_path(
+    REPO_DIR / 'img',
+    SERVER_DIR / 'img',
+)
 
 _df = None
 
@@ -23,4 +39,3 @@ def get_exercise_by_id(ex_id: str):
     if result.empty:
         return None
     return result.iloc[0].to_dict()
-

--- a/server_legacy/app/main.py
+++ b/server_legacy/app/main.py
@@ -6,8 +6,22 @@ from . import db
 
 app = FastAPI(title='GymApp')
 
+SERVER_DIR = Path(__file__).resolve().parent.parent
+REPO_DIR = SERVER_DIR.parent
+
+
+def _first_existing_path(*paths: Path) -> Path:
+    for candidate in paths:
+        if candidate.exists():
+            return candidate
+    return paths[0]
+
+
 # Path to the frontend build directory
-FRONTEND_DIR = Path(__file__).resolve().parent.parent / 'client' / 'dist'
+FRONTEND_DIR = _first_existing_path(
+    REPO_DIR / 'client' / 'dist',
+    SERVER_DIR / 'client' / 'dist',
+)
 
 # Mount images folder
 app.mount('/img', StaticFiles(directory=db.IMG_DIR), name='img')


### PR DESCRIPTION
### Motivation
- The legacy FastAPI backend was failing to load exercise data and images because it assumed the Excel and `img/` lived under `server_legacy/` rather than the repository root in the current project layout.
- The frontend build lookup also assumed `server_legacy/client/dist`, preventing the SPA from being served when `client/dist` is at the repo root.

### Description
- Added a small helper `_first_existing_path` in `server_legacy/app/db.py` and `server_legacy/app/main.py` to pick the first existing candidate path and preserve backward compatibility with the previous layout.
- Updated `server_legacy/app/db.py` to resolve `EXCEL_PATH` and `IMG_DIR` from either the repository root or `server_legacy/` directory.
- Updated `server_legacy/app/main.py` to resolve `FRONTEND_DIR` from either the repository root or `server_legacy/` directory and keep mounting static assets unchanged.

### Testing
- Ran a quick import/inspection script (`python - <<'PY' ...`) which prints `db.EXCEL_PATH`, `db.IMG_DIR`, verifies existence and loads exercises, and it reported 58 rows successfully.
- Compiled the server files with `python -m compileall server_legacy/app`, which completed without errors.
- Attempted a `fastapi.testclient` smoke test but it could not run because the environment is missing the `httpx` dependency (test aborted with an explanatory error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ca0ef3b48330baf2fbb26fdca83c)