### PR TITLE
Ajustar validaciones del onboarding y fallback de edad en perfil

### DIFF
--- a/client/src/components/Onboarding/Step1.tsx
+++ b/client/src/components/Onboarding/Step1.tsx
@@ -8,7 +8,11 @@ const step1Schema = z.object({
   nombre: z.string().min(1, 'Requerido'),
   email: z.string().email('Email inválido'),
   password: z.string().min(6, 'Mínimo 6 caracteres'),
-  fechaNacimiento: z.string(),
+  fechaNacimiento: z
+    .string()
+    .min(1, 'Requerido')
+    .refine((value) => !Number.isNaN(new Date(value).getTime()), 'Fecha inválida')
+    .refine((value) => new Date(value).getTime() <= Date.now(), 'La fecha no puede ser futura'),
   alturaCm: z.number({ invalid_type_error: 'Número' }).min(30).max(300),
   pesoKg: z.number({ invalid_type_error: 'Número' }).min(20).max(500),
   nivel: z.enum(['Principiante', 'Intermedio', 'Avanzado']),
@@ -22,7 +26,11 @@ type Step1Data = z.infer<typeof step1Schema>
 export default function Step1() {
   const { register, handleSubmit, formState: { errors, isValid } } = useForm<Step1Data>({
     resolver: zodResolver(step1Schema),
-    mode: 'onChange'
+    mode: 'onChange',
+    defaultValues: {
+      diasDisponibles: [],
+      fechaNacimiento: '',
+    },
   })
   const navigate = useNavigate()
   const { setUserData } = useUser()
@@ -42,31 +50,32 @@ export default function Step1() {
       <div>
         <label className="label">Nombre</label>
         <input {...register('nombre')} />
-        {errors.nombre && <span className="text-red-500">{errors.nombre.message}</span>}
+        {errors.nombre && <span className="error-text">{errors.nombre.message}</span>}
       </div>
       <div>
         <label className="label">Email</label>
         <input type="email" {...register('email')} />
-        {errors.email && <span className="text-red-500">{errors.email.message}</span>}
+        {errors.email && <span className="error-text">{errors.email.message}</span>}
       </div>
       <div>
         <label className="label">Contraseña</label>
         <input type="password" {...register('password')} />
-        {errors.password && <span className="text-red-500">{errors.password.message}</span>}
+        {errors.password && <span className="error-text">{errors.password.message}</span>}
       </div>
       <div>
         <label className="label">Fecha de nacimiento</label>
         <input type="date" {...register('fechaNacimiento')} />
+        {errors.fechaNacimiento && <span className="error-text">{errors.fechaNacimiento.message}</span>}
       </div>
       <div>
         <label className="label">Altura (cm)</label>
         <input type="number" {...register('alturaCm',{valueAsNumber:true})} />
-        {errors.alturaCm && <span className="text-red-500">{errors.alturaCm.message}</span>}
+        {errors.alturaCm && <span className="error-text">{errors.alturaCm.message}</span>}
       </div>
       <div>
         <label className="label">Peso (kg)</label>
         <input type="number" {...register('pesoKg',{valueAsNumber:true})} />
-        {errors.pesoKg && <span className="text-red-500">{errors.pesoKg.message}</span>}
+        {errors.pesoKg && <span className="error-text">{errors.pesoKg.message}</span>}
       </div>
       <div>
         <label className="label">Nivel</label>
@@ -105,7 +114,7 @@ export default function Step1() {
             </label>
           ))}
         </div>
-        {errors.diasDisponibles && <span className="text-red-500">Seleccione al menos uno</span>}
+        {errors.diasDisponibles && <span className="error-text">Seleccione al menos uno</span>}
       </div>
       <button type="submit" disabled={!isValid} className="bg-blue-500 text-white px-4 py-2" style={{ alignSelf: 'flex-end' }}>
         Siguiente

--- a/client/src/components/Onboarding/Step2.tsx
+++ b/client/src/components/Onboarding/Step2.tsx
@@ -8,9 +8,9 @@ const step2Schema = z.object({
   equipo: z.string().optional(),
   lesiones: z.string().optional(),
   medidas: z.object({
-    brazoCm: z.number().optional(),
-    cinturaCm: z.number().optional(),
-    caderaCm: z.number().optional()
+    brazoCm: z.number().finite().optional(),
+    cinturaCm: z.number().finite().optional(),
+    caderaCm: z.number().finite().optional()
   }).optional(),
   notificaciones: z.object({
     pesoMensual: z.boolean().optional(),
@@ -23,7 +23,7 @@ type Step2Data = z.infer<typeof step2Schema>
 export default function Step2() {
   const { register, handleSubmit } = useForm<Step2Data>({
     resolver: zodResolver(step2Schema),
-    mode: 'onChange'
+    mode: 'onChange',
   })
   const navigate = useNavigate()
   const { setUserData, finalizeUser } = useUser()
@@ -59,9 +59,9 @@ export default function Step2() {
         <fieldset className="panel" style={{ background: '#f8faff' }}>
           <legend className="label">Medidas adicionales (cm)</legend>
           <div className="row">
-            <input placeholder="Brazo" type="number" {...register('medidas.brazoCm', { valueAsNumber: true })} className="w-20" />
-            <input placeholder="Cintura" type="number" {...register('medidas.cinturaCm', { valueAsNumber: true })} className="w-20" />
-            <input placeholder="Cadera" type="number" {...register('medidas.caderaCm', { valueAsNumber: true })} className="w-20" />
+            <input placeholder="Brazo" type="number" {...register('medidas.brazoCm', { setValueAs: (v) => v === '' ? undefined : Number(v) })} className="w-20" />
+            <input placeholder="Cintura" type="number" {...register('medidas.cinturaCm', { setValueAs: (v) => v === '' ? undefined : Number(v) })} className="w-20" />
+            <input placeholder="Cadera" type="number" {...register('medidas.caderaCm', { setValueAs: (v) => v === '' ? undefined : Number(v) })} className="w-20" />
           </div>
         </fieldset>
         <div className="stack" style={{ gap: '0.5rem' }}>

--- a/client/src/components/Profile/ProfilePage.tsx
+++ b/client/src/components/Profile/ProfilePage.tsx
@@ -7,7 +7,10 @@ export default function ProfilePage() {
 
   if (!user) return <p className="page-shell">No hay datos de usuario.</p>
 
-  const edad = Math.floor((Date.now() - new Date(user.fechaNacimiento).getTime()) / (1000 * 60 * 60 * 24 * 365.25))
+  const birthDate = new Date(user.fechaNacimiento)
+  const edad = Number.isNaN(birthDate.getTime())
+    ? '-'
+    : Math.floor((Date.now() - birthDate.getTime()) / (1000 * 60 * 60 * 24 * 365.25))
   const imc = (user.pesoKg / ((user.alturaCm / 100) ** 2)).toFixed(1)
 
   return (


### PR DESCRIPTION
### Motivation
- Evitar errores al completar el onboarding por campos no inicializados o entradas inválidas (fecha y medidas numéricas). 
- Evitar mostrar `NaN` en la vista de perfil cuando el usuario tiene una fecha de nacimiento inválida en los datos almacenados.

### Description
- Fortalecí la validación de `fechaNacimiento` en `client/src/components/Onboarding/Step1.tsx` para exigir valor, validar el formato de fecha y rechazar fechas futuras. 
- Añadí `defaultValues` en el formulario de Step 1 para estabilizar el comportamiento desde el primer render (`diasDisponibles` y `fechaNacimiento`).
- Unifiqué el estilo de mensajes de error en Step 1 usando la clase existente `error-text`. 
- En `client/src/components/Onboarding/Step2.tsx` marqué las medidas opcionales como `number().finite().optional()` y cambié el registro de inputs para convertir cadenas vacías a `undefined` evitando `NaN` en la validación/envío. 
- En `client/src/components/Profile/ProfilePage.tsx` añadí un fallback seguro para calcular la edad a partir de `fechaNacimiento` y mostrar `-` si la fecha es inválida.

### Testing
- Ejecuté `cd client && npm run lint` y la verificación de lint pasó correctamente. 
- Ejecuté `cd client && npm run build` y el build de producción con Vite se completó exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caaf17eb3883309db552906914b464)