### PR TITLE
Agregar registro de actividad con resúmenes semanal/mensual/anual

### DIFF
--- a/client/src/components/Profile/CalendarPage.tsx
+++ b/client/src/components/Profile/CalendarPage.tsx
@@ -1,12 +1,236 @@
+import { FormEvent, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { ACTIVITY_LABELS, type ActivityEntry, type ActivityType } from '../../models/activity'
+import { loadActivities, saveActivities } from '../../services/activity'
+
+interface WeeklyGoal {
+  sessions: number
+  minutes: number
+}
+
+const WEEKLY_GOAL: WeeklyGoal = {
+  sessions: 4,
+  minutes: 180
+}
+
+const todayISO = new Date().toISOString().slice(0, 10)
+
+function startOfWeek(date: Date): Date {
+  const copy = new Date(date)
+  const day = copy.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  copy.setDate(copy.getDate() + diff)
+  copy.setHours(0, 0, 0, 0)
+  return copy
+}
+
+function isSameMonth(date: Date, ref: Date): boolean {
+  return date.getMonth() === ref.getMonth() && date.getFullYear() === ref.getFullYear()
+}
+
+function isSameYear(date: Date, ref: Date): boolean {
+  return date.getFullYear() === ref.getFullYear()
+}
+
+function summarize(entries: ActivityEntry[]) {
+  const totalMinutes = entries.reduce((acc, item) => acc + item.durationMinutes, 0)
+  const totalKm = entries.reduce((acc, item) => acc + (item.distanceKm ?? 0), 0)
+  return {
+    sessions: entries.length,
+    totalMinutes,
+    totalKm: Number(totalKm.toFixed(1))
+  }
+}
 
 export default function CalendarPage() {
+  const [entries, setEntries] = useState<ActivityEntry[]>(() => loadActivities())
+  const [date, setDate] = useState(todayISO)
+  const [type, setType] = useState<ActivityType>('running')
+  const [durationMinutes, setDurationMinutes] = useState(30)
+  const [distanceKm, setDistanceKm] = useState('')
+  const [exercises, setExercises] = useState('')
+  const [notes, setNotes] = useState('')
+
+  const sortedEntries = useMemo(
+    () => [...entries].sort((a, b) => b.date.localeCompare(a.date)),
+    [entries]
+  )
+
+  const now = new Date()
+  const weekStart = startOfWeek(now)
+
+  const weeklyEntries = useMemo(
+    () => entries.filter((entry) => new Date(entry.date) >= weekStart),
+    [entries, weekStart]
+  )
+
+  const monthlyEntries = useMemo(
+    () => entries.filter((entry) => isSameMonth(new Date(entry.date), now)),
+    [entries, now]
+  )
+
+  const yearlyEntries = useMemo(
+    () => entries.filter((entry) => isSameYear(new Date(entry.date), now)),
+    [entries, now]
+  )
+
+  const weeklySummary = summarize(weeklyEntries)
+  const monthlySummary = summarize(monthlyEntries)
+  const yearlySummary = summarize(yearlyEntries)
+
+  const weeklyStatusText =
+    weeklySummary.sessions >= WEEKLY_GOAL.sessions && weeklySummary.totalMinutes >= WEEKLY_GOAL.minutes
+      ? 'Vas excelente esta semana: cumpliste tus metas 💪'
+      : 'Vas avanzando. Intenta sumar más sesiones o minutos para cumplir la meta semanal.'
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const normalizedDistance = distanceKm.trim() ? Number(distanceKm) : undefined
+
+    const newEntry: ActivityEntry = {
+      id: crypto.randomUUID(),
+      date,
+      type,
+      durationMinutes,
+      distanceKm: Number.isFinite(normalizedDistance) ? normalizedDistance : undefined,
+      exercises: exercises.trim() || undefined,
+      notes: notes.trim() || undefined,
+      createdAt: new Date().toISOString()
+    }
+
+    const updated = [newEntry, ...entries]
+    setEntries(updated)
+    saveActivities(updated)
+
+    setDurationMinutes(30)
+    setDistanceKm('')
+    setExercises('')
+    setNotes('')
+  }
+
   return (
-    <div className="page-shell">
+    <div className="page-shell stack">
       <section className="panel">
-        <h1 className="text-xl font-bold mb-4">Calendario</h1>
-        <p style={{ color: '#475569' }}>Próximamente vas a poder visualizar tus sesiones con recordatorios y progreso semanal.</p>
+        <h1 className="text-xl font-bold mb-2">Registro de actividad</h1>
+        <p style={{ color: '#475569', marginTop: 0 }}>
+          Aquí podés guardar todo lo que hacés: correr, pesas, caminatas, bici y más.
+        </p>
         <Link to="/perfil" className="text-blue-500">Volver al perfil</Link>
+      </section>
+
+      <section className="panel">
+        <h2 className="text-xl font-bold mb-2">Agregar actividad</h2>
+        <form className="form-grid" onSubmit={handleSubmit}>
+          <label>
+            <span className="label">Fecha</span>
+            <input type="date" value={date} max={todayISO} onChange={(e) => setDate(e.target.value)} required />
+          </label>
+
+          <label>
+            <span className="label">Tipo</span>
+            <select value={type} onChange={(e) => setType(e.target.value as ActivityType)}>
+              {Object.entries(ACTIVITY_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>{label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span className="label">Duración (min)</span>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={durationMinutes}
+              onChange={(e) => setDurationMinutes(Number(e.target.value))}
+              required
+            />
+          </label>
+
+          <label>
+            <span className="label">Distancia en km (opcional)</span>
+            <input
+              type="number"
+              min={0}
+              step={0.1}
+              placeholder="Ej: 5"
+              value={distanceKm}
+              onChange={(e) => setDistanceKm(e.target.value)}
+            />
+          </label>
+
+          <label style={{ gridColumn: '1 / -1' }}>
+            <span className="label">Ejercicios realizados (opcional)</span>
+            <input
+              type="text"
+              placeholder="Ej: sentadilla 4x10, press banca 3x8"
+              value={exercises}
+              onChange={(e) => setExercises(e.target.value)}
+            />
+          </label>
+
+          <label style={{ gridColumn: '1 / -1' }}>
+            <span className="label">Notas (opcional)</span>
+            <textarea
+              placeholder="Cómo te sentiste, cargas usadas, etc."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </label>
+
+          <div>
+            <button type="submit" className="bg-green-600">Guardar actividad</button>
+          </div>
+        </form>
+      </section>
+
+      <section className="panel">
+        <h2 className="text-xl font-bold mb-2">Progreso semanal / mensual / anual</h2>
+        <div className="form-grid">
+          <article>
+            <h3 style={{ marginBottom: '0.5rem' }}>Semana actual</h3>
+            <p>Sesiones: <strong>{weeklySummary.sessions}</strong></p>
+            <p>Minutos: <strong>{weeklySummary.totalMinutes}</strong></p>
+            <p>Kilómetros: <strong>{weeklySummary.totalKm}</strong></p>
+            <p style={{ color: '#1e3a8a' }}>{weeklyStatusText}</p>
+          </article>
+          <article>
+            <h3 style={{ marginBottom: '0.5rem' }}>Mes actual</h3>
+            <p>Sesiones: <strong>{monthlySummary.sessions}</strong></p>
+            <p>Minutos: <strong>{monthlySummary.totalMinutes}</strong></p>
+            <p>Kilómetros: <strong>{monthlySummary.totalKm}</strong></p>
+          </article>
+          <article>
+            <h3 style={{ marginBottom: '0.5rem' }}>Año actual</h3>
+            <p>Sesiones: <strong>{yearlySummary.sessions}</strong></p>
+            <p>Minutos: <strong>{yearlySummary.totalMinutes}</strong></p>
+            <p>Kilómetros: <strong>{yearlySummary.totalKm}</strong></p>
+          </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <h2 className="text-xl font-bold mb-2">Historial</h2>
+        {sortedEntries.length === 0 ? (
+          <p style={{ color: '#475569' }}>Todavía no cargaste actividades.</p>
+        ) : (
+          <div className="stack">
+            {sortedEntries.map((entry) => (
+              <article key={entry.id} className="card" style={{ cursor: 'default' }}>
+                <p style={{ margin: '0 0 0.25rem 0' }}>
+                  <strong>{entry.date}</strong> · {ACTIVITY_LABELS[entry.type]}
+                </p>
+                <p style={{ margin: 0 }}>
+                  Duración: {entry.durationMinutes} min
+                  {entry.distanceKm ? ` · Distancia: ${entry.distanceKm} km` : ''}
+                </p>
+                {entry.exercises && <p style={{ margin: '0.35rem 0 0 0' }}><strong>Ejercicios:</strong> {entry.exercises}</p>}
+                {entry.notes && <p style={{ margin: '0.35rem 0 0 0' }}><strong>Notas:</strong> {entry.notes}</p>}
+              </article>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   )

--- a/client/src/components/Profile/ProfilePage.tsx
+++ b/client/src/components/Profile/ProfilePage.tsx
@@ -26,7 +26,7 @@ export default function ProfilePage() {
           <p><strong>IMC:</strong> {imc}</p>
         </div>
         <div className="row" style={{ marginTop: '1rem' }}>
-          <button onClick={() => navigate('/calendario')} className="bg-gray-500 text-white px-4 py-2">Ir a Calendario</button>
+          <button onClick={() => navigate('/calendario')} className="bg-gray-500 text-white px-4 py-2">Registro de actividad</button>
           <button onClick={() => navigate('/ejercicios')} className="bg-blue-600 text-white px-4 py-2">Ver Ejercicios</button>
         </div>
       </section>

--- a/client/src/models/activity.ts
+++ b/client/src/models/activity.ts
@@ -1,0 +1,20 @@
+export type ActivityType = 'running' | 'weights' | 'cycling' | 'walking' | 'other'
+
+export interface ActivityEntry {
+  id: string
+  date: string
+  type: ActivityType
+  durationMinutes: number
+  distanceKm?: number
+  exercises?: string
+  notes?: string
+  createdAt: string
+}
+
+export const ACTIVITY_LABELS: Record<ActivityType, string> = {
+  running: 'Correr',
+  weights: 'Pesas',
+  cycling: 'Bicicleta',
+  walking: 'Caminar',
+  other: 'Otro'
+}

--- a/client/src/services/activity.ts
+++ b/client/src/services/activity.ts
@@ -1,0 +1,19 @@
+import type { ActivityEntry } from '../models/activity'
+
+const STORAGE_KEY = 'activity_log'
+
+export function loadActivities(): ActivityEntry[] {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (!stored) return []
+
+  try {
+    const parsed = JSON.parse(stored) as ActivityEntry[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function saveActivities(entries: ActivityEntry[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+}


### PR DESCRIPTION
### Motivation

- Añadir un módulo donde el usuario pueda registrar sesiones de actividad (correr, pesas, bici, caminar, etc.) y obtener resúmenes por distintos periodos. 

### Description

- Se creó el modelo tipado `ActivityEntry` y `ActivityType` en `client/src/models/activity.ts` junto con etiquetas en español para los tipos de actividad. 
- Se añadió un servicio de persistencia en `localStorage` en `client/src/services/activity.ts` usando la clave `activity_log` para cargar/guardar el historial. 
- Se reemplazó el contenido de la pantalla `Calendario` por un `Registro de actividad` en `client/src/components/Profile/CalendarPage.tsx` que permite crear entradas con fecha, tipo, duración, distancia opcional, ejercicios y notas, y muestra el historial. 
- Se implementaron cálculos y vistas de resumen automático para la semana actual, mes actual y año actual (sesiones, minutos y kilómetros) y un mensaje de estado semanal comparado con una meta base, y se actualizó el texto del botón del perfil en `client/src/components/Profile/ProfilePage.tsx` para apuntar al nuevo flujo. 

### Testing

- Ejecuté la compilación de frontend con `cd client && npm run build` y la construcción finalizó correctamente (`vite build` completado). 
- No se ejecutaron tests unitarios automatizados adicionales en este cambio; la verificación fue la compilación de producción del cliente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd685412088330af1bbdb2531e52e4)