### PR TITLE
Implement local login/register flow with persisted user session

### DIFF
--- a/client/src/Landing.tsx
+++ b/client/src/Landing.tsx
@@ -1,7 +1,18 @@
 import { useNavigate } from 'react-router-dom'
+import { useUser } from './hooks/useUser'
 
 function Landing() {
   const navigate = useNavigate()
+  const { isAuthenticated, user } = useUser()
+
+  const handleStart = () => {
+    if (!isAuthenticated) {
+      navigate('/auth')
+      return
+    }
+
+    navigate(user ? '/perfil' : '/step1')
+  }
 
   return (
     <div className="page-shell" style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
@@ -11,8 +22,8 @@ function Landing() {
         <p style={{ color: '#475569', margin: '0.75rem auto 2rem', maxWidth: 460 }}>
           Planes personalizados, seguimiento inteligente y una experiencia mucho más limpia para mantener tu progreso siempre visible.
         </p>
-        <button onClick={() => navigate('/step1')}>
-          Comenzar ahora
+        <button onClick={handleStart}>
+          {isAuthenticated ? 'Ir a mi cuenta' : 'Comenzar ahora'}
         </button>
       </section>
     </div>

--- a/client/src/components/Onboarding/AuthPage.tsx
+++ b/client/src/components/Onboarding/AuthPage.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useUser } from '../../hooks/useUser'
+
+export default function AuthPage() {
+  const [mode, setMode] = useState<'login' | 'register'>('login')
+  const [nombre, setNombre] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+  const { register, login } = useUser()
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError('')
+
+    if (!email || !password) {
+      setError('Completá email y contraseña.')
+      return
+    }
+
+    if (mode === 'register') {
+      if (!nombre.trim()) {
+        setError('Completá tu nombre para registrarte.')
+        return
+      }
+      const result = await register({ nombre: nombre.trim(), email, password })
+      navigate(result.hasProfile ? '/perfil' : '/step1')
+      return
+    }
+
+    const result = await login({ email, password })
+    if (!result.success) {
+      setError('Credenciales inválidas. Revisá email y contraseña.')
+      return
+    }
+
+    navigate(result.hasProfile ? '/perfil' : '/step1')
+  }
+
+  return (
+    <div className="page-shell" style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+      <section className="panel" style={{ width: '100%', maxWidth: 520 }}>
+        <h1 style={{ marginTop: 0 }}>{mode === 'login' ? 'Iniciar sesión' : 'Crear cuenta'}</h1>
+        <p style={{ color: '#475569' }}>
+          Guardamos tu usuario para que no tengas que cargar todo cada vez.
+        </p>
+
+        <form onSubmit={handleSubmit} className="stack">
+          {mode === 'register' && (
+            <label>
+              <span className="label">Nombre</span>
+              <input value={nombre} onChange={(e) => setNombre(e.target.value)} />
+            </label>
+          )}
+
+          <label>
+            <span className="label">Email</span>
+            <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </label>
+
+          <label>
+            <span className="label">Contraseña</span>
+            <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          </label>
+
+          {error && <p className="error-text" style={{ margin: 0 }}>{error}</p>}
+
+          <button type="submit">{mode === 'login' ? 'Entrar' : 'Registrarme'}</button>
+        </form>
+
+        <button
+          type="button"
+          onClick={() => {
+            setError('')
+            setMode((prev) => (prev === 'login' ? 'register' : 'login'))
+          }}
+          className="bg-gray-500"
+          style={{ marginTop: '0.75rem' }}
+        >
+          {mode === 'login' ? 'No tengo cuenta' : 'Ya tengo cuenta'}
+        </button>
+      </section>
+    </div>
+  )
+}

--- a/client/src/components/Onboarding/OnboardingRouter.tsx
+++ b/client/src/components/Onboarding/OnboardingRouter.tsx
@@ -1,21 +1,35 @@
-import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import Landing from '../../Landing'
+import { useUser } from '../../hooks/useUser'
+import ExerciseList from '../Exercises/ExerciseList'
+import CalendarPage from '../Profile/CalendarPage'
+import ProfilePage from '../Profile/ProfilePage'
+import AuthPage from './AuthPage'
 import Step1 from './Step1'
 import Step2 from './Step2'
-import ProfilePage from '../Profile/ProfilePage'
-import CalendarPage from '../Profile/CalendarPage'
-import ExerciseList from '../Exercises/ExerciseList'
+
+function ProtectedRoute({ children }: { children: ReactElement }) {
+  const { isAuthenticated } = useUser()
+
+  if (!isAuthenticated) {
+    return <Navigate to="/auth" replace />
+  }
+
+  return children
+}
 
 export default function OnboardingRouter() {
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/step1" element={<Step1 />} />
-        <Route path="/step2" element={<Step2 />} />
-        <Route path="/perfil" element={<ProfilePage />} />
-        <Route path="/calendario" element={<CalendarPage />} />
-        <Route path="/ejercicios" element={<ExerciseList />} />
+        <Route path="/auth" element={<AuthPage />} />
+        <Route path="/step1" element={<ProtectedRoute><Step1 /></ProtectedRoute>} />
+        <Route path="/step2" element={<ProtectedRoute><Step2 /></ProtectedRoute>} />
+        <Route path="/perfil" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
+        <Route path="/calendario" element={<ProtectedRoute><CalendarPage /></ProtectedRoute>} />
+        <Route path="/ejercicios" element={<ProtectedRoute><ExerciseList /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </BrowserRouter>

--- a/client/src/components/Onboarding/Step1.tsx
+++ b/client/src/components/Onboarding/Step1.tsx
@@ -24,16 +24,24 @@ const step1Schema = z.object({
 type Step1Data = z.infer<typeof step1Schema>
 
 export default function Step1() {
+  const { user, setUserData } = useUser()
   const { register, handleSubmit, formState: { errors, isValid } } = useForm<Step1Data>({
     resolver: zodResolver(step1Schema),
     mode: 'onChange',
     defaultValues: {
-      diasDisponibles: [],
-      fechaNacimiento: '',
+      nombre: user?.nombre || '',
+      email: user?.email || '',
+      password: user?.password || '',
+      fechaNacimiento: user?.fechaNacimiento || '',
+      alturaCm: user?.alturaCm,
+      pesoKg: user?.pesoKg,
+      nivel: user?.nivel || 'Principiante',
+      actividad: user?.actividad || 'Sedentaria',
+      objetivo: user?.objetivo || 'Masa',
+      diasDisponibles: user?.diasDisponibles || [],
     },
   })
   const navigate = useNavigate()
-  const { setUserData } = useUser()
 
   const onSubmit = (data: Step1Data) => {
     setUserData(data)

--- a/client/src/components/Profile/ProfilePage.tsx
+++ b/client/src/components/Profile/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useUser } from '../../hooks/useUser'
 
 export default function ProfilePage() {
   const navigate = useNavigate()
-  const { user } = useUser()
+  const { user, logout } = useUser()
 
   if (!user) return <p className="page-shell">No hay datos de usuario.</p>
 
@@ -28,6 +28,7 @@ export default function ProfilePage() {
         <div className="row" style={{ marginTop: '1rem' }}>
           <button onClick={() => navigate('/calendario')} className="bg-gray-500 text-white px-4 py-2">Registro de actividad</button>
           <button onClick={() => navigate('/ejercicios')} className="bg-blue-600 text-white px-4 py-2">Ver Ejercicios</button>
+          <button onClick={() => { logout(); navigate('/auth') }} className="bg-gray-500 text-white px-4 py-2">Cerrar sesión</button>
         </div>
       </section>
 

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -1,18 +1,41 @@
-import { createContext, createElement, useContext, useEffect, useState } from 'react'
+import { createContext, createElement, useContext, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { User } from '../models/user'
 import { saveUser, loadUser } from '../services/api'
+import {
+  getSavedAccount,
+  getSessionEmail,
+  loginAccount,
+  logoutAccount,
+  registerAccount,
+} from '../services/authLocal'
+
+interface Credentials {
+  nombre?: string
+  email: string
+  password: string
+}
+
+interface AuthResult {
+  success: boolean
+  hasProfile: boolean
+}
 
 interface UserContextValue {
   user: User | null
+  isAuthenticated: boolean
   setUserData: (data: Partial<User>) => Partial<User>
   finalizeUser: (data?: Partial<User>) => Promise<void>
+  register: (credentials: Credentials) => Promise<AuthResult>
+  login: (credentials: Credentials) => Promise<AuthResult>
+  logout: () => void
 }
 
 const UserContext = createContext<UserContextValue | undefined>(undefined)
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
+  const [sessionEmail, setSessionEmail] = useState<string | null>(null)
 
   const setUserData = (data: Partial<User>) => {
     setUser((prev) => ({ ...(prev || ({} as User)), ...data } as User))
@@ -28,13 +51,69 @@ export function UserProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  const register = async ({ nombre, email, password }: Credentials): Promise<AuthResult> => {
+    registerAccount({
+      nombre: nombre || email,
+      email,
+      password,
+    })
+
+    setSessionEmail(email)
+
+    const currentUser = await loadUser()
+    if (currentUser && currentUser.email.toLowerCase() === email.toLowerCase()) {
+      setUser(currentUser)
+      return { success: true, hasProfile: true }
+    }
+
+    setUser(null)
+    return { success: true, hasProfile: false }
+  }
+
+  const login = async ({ email, password }: Credentials): Promise<AuthResult> => {
+    const ok = loginAccount(email, password)
+    if (!ok) return { success: false, hasProfile: false }
+
+    setSessionEmail(email)
+
+    const loadedUser = await loadUser()
+    if (loadedUser && loadedUser.email.toLowerCase() === email.toLowerCase()) {
+      setUser(loadedUser)
+      return { success: true, hasProfile: true }
+    }
+
+    setUser(null)
+    return { success: true, hasProfile: false }
+  }
+
+  const logout = () => {
+    logoutAccount()
+    setSessionEmail(null)
+    setUser(null)
+  }
+
   useEffect(() => {
-    loadUser().then((u) => u && setUser(u))
+    const email = getSessionEmail()
+    setSessionEmail(email)
+
+    if (!email) return
+
+    loadUser().then((loadedUser) => {
+      if (loadedUser && loadedUser.email.toLowerCase() === email.toLowerCase()) {
+        setUser(loadedUser)
+      }
+    })
   }, [])
+
+  const isAuthenticated = useMemo(() => {
+    const account = getSavedAccount()
+    if (!account || !sessionEmail) return false
+    return account.email.toLowerCase() === sessionEmail.toLowerCase()
+  }, [sessionEmail])
 
   return createElement(
     UserContext.Provider,
-    { value: { user, setUserData, finalizeUser } },
+    { value: { user, isAuthenticated, setUserData, finalizeUser, register, login, logout } },
     children
   )
 }

--- a/client/src/services/authLocal.ts
+++ b/client/src/services/authLocal.ts
@@ -1,0 +1,45 @@
+export interface LocalAccount {
+  email: string
+  password: string
+  nombre: string
+}
+
+const ACCOUNT_KEY = 'auth_account'
+const SESSION_KEY = 'auth_session'
+
+export function getSavedAccount(): LocalAccount | null {
+  const stored = localStorage.getItem(ACCOUNT_KEY)
+  if (!stored) return null
+
+  try {
+    return JSON.parse(stored) as LocalAccount
+  } catch {
+    return null
+  }
+}
+
+export function registerAccount(account: LocalAccount): void {
+  localStorage.setItem(ACCOUNT_KEY, JSON.stringify(account))
+  localStorage.setItem(SESSION_KEY, account.email)
+}
+
+export function loginAccount(email: string, password: string): boolean {
+  const account = getSavedAccount()
+  if (!account) return false
+
+  const isValid = account.email.toLowerCase() === email.toLowerCase() && account.password === password
+
+  if (isValid) {
+    localStorage.setItem(SESSION_KEY, account.email)
+  }
+
+  return isValid
+}
+
+export function getSessionEmail(): string | null {
+  return localStorage.getItem(SESSION_KEY)
+}
+
+export function logoutAccount(): void {
+  localStorage.removeItem(SESSION_KEY)
+}


### PR DESCRIPTION
### Motivation
- Avoid forcing users to re-enter onboarding data each visit by adding a lightweight local authentication and persisted session so profile and app state are retained.

### Description
- Added an `AuthPage` component and `/auth` route to let users register or sign in with a simple form and navigate to profile or onboarding accordingly.
- Implemented a local auth service at `client/src/services/authLocal.ts` that stores an account and active session in `localStorage` (`auth_account` / `auth_session`).
- Extended the user context in `client/src/hooks/useUser.ts` with `register`, `login`, `logout`, `isAuthenticated`, session recovery on load, and integration with existing `saveUser`/`loadUser` profile persistence.
- Protected onboarding/profile/activity/exercise routes with a `ProtectedRoute` in `client/src/components/Onboarding/OnboardingRouter.tsx`, updated `client/src/Landing.tsx` CTA behavior, added logout to `client/src/components/Profile/ProfilePage.tsx`, and prefilling Step 1 from saved profile in `client/src/components/Onboarding/Step1.tsx`.

### Testing
- Ran the production frontend build with `cd client && npm run build`, which completed successfully without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6ba659e88330a0e0f731e4df677f)