### PR TITLE
Update landing CTA to 'Login o registrarse' for unauthenticated users

### DIFF
--- a/client/src/Landing.tsx
+++ b/client/src/Landing.tsx
@@ -23,7 +23,7 @@ function Landing() {
           Planes personalizados, seguimiento inteligente y una experiencia mucho más limpia para mantener tu progreso siempre visible.
         </p>
         <button onClick={handleStart}>
-          {isAuthenticated ? 'Ir a mi cuenta' : 'Comenzar ahora'}
+          {isAuthenticated ? 'Ir a mi cuenta' : 'Login o registrarse'}
         </button>
       </section>
     </div>


### PR DESCRIPTION
### Motivation
- Hacer explícita la acción de entrada en la landing mostrando "Login o registrarse" para usuarios no autenticados en lugar de "Comenzar ahora".

### Description
- Reemplacé el texto `{isAuthenticated ? 'Ir a mi cuenta' : 'Comenzar ahora'}` por `{isAuthenticated ? 'Ir a mi cuenta' : 'Login o registrarse'}` en `client/src/Landing.tsx`, sin cambiar la lógica de navegación (navega a `/auth` si no está autenticado, y a `/perfil` o `/step1` si lo está).

### Testing
- Ejecuté `cd client && npm run build` y la compilación de producción con Vite terminó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd774e5bcc83308bbfa788560c1c84)