### PR TITLE
Registro de actividad: selección guiada de ejercicios por músculo (solo para pesas)

### DIFF
--- a/client/src/components/Profile/CalendarPage.tsx
+++ b/client/src/components/Profile/CalendarPage.tsx
@@ -56,7 +56,7 @@ export default function CalendarPage() {
   const [type, setType] = useState<ActivityType>('running')
   const [durationMinutes, setDurationMinutes] = useState(30)
   const [distanceKm, setDistanceKm] = useState('')
-  const [exercises, setExercises] = useState('')
+  const [selectedExercises, setSelectedExercises] = useState<string[]>([])
   const [selectedMuscle, setSelectedMuscle] = useState('')
   const [selectedExercise, setSelectedExercise] = useState('')
   const [notes, setNotes] = useState('')
@@ -114,18 +114,14 @@ export default function CalendarPage() {
     setType(newType)
     setSelectedMuscle('')
     setSelectedExercise('')
+    setSelectedExercises([])
   }
 
   const handleAddExercise = () => {
     if (!selectedExercise) return
-    const currentExercises = exercises
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean)
-
-    if (currentExercises.includes(selectedExercise)) return
-
-    setExercises(currentExercises.length > 0 ? `${currentExercises.join(', ')}, ${selectedExercise}` : selectedExercise)
+    if (selectedExercises.includes(selectedExercise)) return
+    setSelectedExercises((prev) => [...prev, selectedExercise])
+    setSelectedExercise('')
   }
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -139,7 +135,7 @@ export default function CalendarPage() {
       type,
       durationMinutes,
       distanceKm: Number.isFinite(normalizedDistance) ? normalizedDistance : undefined,
-      exercises: exercises.trim() || undefined,
+      exercises: showExerciseSelectors && selectedExercises.length > 0 ? selectedExercises.join(', ') : undefined,
       notes: notes.trim() || undefined,
       createdAt: new Date().toISOString()
     }
@@ -150,7 +146,7 @@ export default function CalendarPage() {
 
     setDurationMinutes(30)
     setDistanceKm('')
-    setExercises('')
+    setSelectedExercises([])
     setNotes('')
   }
 
@@ -233,15 +229,18 @@ export default function CalendarPage() {
             </>
           )}
 
-          <label style={{ gridColumn: '1 / -1' }}>
-            <span className="label">Ejercicios realizados (opcional)</span>
-            <input
-              type="text"
-              placeholder="Ej: sentadilla 4x10, press banca 3x8"
-              value={exercises}
-              onChange={(e) => setExercises(e.target.value)}
-            />
-          </label>
+          {showExerciseSelectors && (
+            <label style={{ gridColumn: '1 / -1' }}>
+              <span className="label">Ejercicios seleccionados</span>
+              {selectedExercises.length === 0 ? (
+                <p style={{ margin: '0.35rem 0 0 0', color: '#64748b' }}>
+                  Todavía no agregaste ejercicios para esta sesión.
+                </p>
+              ) : (
+                <p style={{ margin: '0.35rem 0 0 0' }}>{selectedExercises.join(', ')}</p>
+              )}
+            </label>
+          )}
 
           <label style={{ gridColumn: '1 / -1' }}>
             <span className="label">Notas (opcional)</span>


### PR DESCRIPTION
### Motivation
- Facilitar el registro de ejercicios usando selecciones en cascada `tipo → músculo → ejercicio` y evitar mostrar/guardar opciones de ejercicios para actividades como correr o caminar.

### Description
- Reemplacé el estado libre `exercises: string` por `selectedExercises: string[]` y adapté la lógica para manejar una lista de ejercicios seleccionados.
- `handleAddExercise` ahora agrega el ejercicio seleccionado sin duplicados y limpia el selector `selectedExercise` tras agregarlo.
- `handleTypeChange` limpia `selectedMuscle`, `selectedExercise` y `selectedExercises` al cambiar el tipo de actividad, y la UI solo muestra los selectores cuando `ACTIVITY_TYPES_WITH_EXERCISES` lo permite (actualmente `weights`).
- Eliminé el campo de texto libre para ejercicios y añadí una sección `Ejercicios seleccionados` que muestra la lista que se guarda en `newEntry.exercises` únicamente si aplica al tipo de actividad.

### Testing
- Ejecuté la compilación de producción con `npm run build` en `client/` y el proceso finalizó correctamente (Vite build completado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7b81b040833090d061336f63d94f)