### PR TITLE
Agregar series/pesos por ejercicio y detalle desplegable en historial

### DIFF
--- a/client/src/components/Profile/CalendarPage.tsx
+++ b/client/src/components/Profile/CalendarPage.tsx
@@ -1,6 +1,12 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ACTIVITY_LABELS, type ActivityEntry, type ActivityType } from '../../models/activity'
+import {
+  ACTIVITY_LABELS,
+  type ActivityEntry,
+  type ActivityType,
+  type ExerciseSet,
+  type LoggedExercise
+} from '../../models/activity'
 import { loadActivities, saveActivities } from '../../services/activity'
 import exercisesCatalog from '../../data/exercises.json'
 
@@ -22,6 +28,12 @@ interface CatalogExercise {
   'Nombre (ES)': string
   'Zona principal': string
 }
+
+const DEFAULT_SETS: ExerciseSet[] = [
+  { reps: '', weightKg: '' },
+  { reps: '', weightKg: '' },
+  { reps: '', weightKg: '' }
+]
 
 function startOfWeek(date: Date): Date {
   const copy = new Date(date)
@@ -57,6 +69,7 @@ export default function CalendarPage() {
   const [durationMinutes, setDurationMinutes] = useState(30)
   const [distanceKm, setDistanceKm] = useState('')
   const [selectedExercises, setSelectedExercises] = useState<string[]>([])
+  const [exerciseDetails, setExerciseDetails] = useState<Record<string, ExerciseSet[]>>({})
   const [selectedMuscle, setSelectedMuscle] = useState('')
   const [selectedExercise, setSelectedExercise] = useState('')
   const [notes, setNotes] = useState('')
@@ -115,13 +128,63 @@ export default function CalendarPage() {
     setSelectedMuscle('')
     setSelectedExercise('')
     setSelectedExercises([])
+    setExerciseDetails({})
   }
 
   const handleAddExercise = () => {
     if (!selectedExercise) return
     if (selectedExercises.includes(selectedExercise)) return
     setSelectedExercises((prev) => [...prev, selectedExercise])
+    setExerciseDetails((prev) => ({
+      ...prev,
+      [selectedExercise]: DEFAULT_SETS.map((set) => ({ ...set }))
+    }))
     setSelectedExercise('')
+  }
+
+  const handleSetChange = (
+    exerciseName: string,
+    setIndex: number,
+    field: keyof ExerciseSet,
+    value: string
+  ) => {
+    setExerciseDetails((prev) => {
+      const exerciseSets = prev[exerciseName] ?? DEFAULT_SETS.map((set) => ({ ...set }))
+      const updatedSets = exerciseSets.map((set, index) =>
+        index === setIndex ? { ...set, [field]: value } : set
+      )
+      return {
+        ...prev,
+        [exerciseName]: updatedSets
+      }
+    })
+  }
+
+  const handleAddSet = (exerciseName: string) => {
+    setExerciseDetails((prev) => {
+      const exerciseSets = prev[exerciseName] ?? DEFAULT_SETS.map((set) => ({ ...set }))
+      return {
+        ...prev,
+        [exerciseName]: [...exerciseSets, { reps: '', weightKg: '' }]
+      }
+    })
+  }
+
+  const buildExerciseDetails = (): LoggedExercise[] | undefined => {
+    if (!showExerciseSelectors || selectedExercises.length === 0) return undefined
+
+    const details = selectedExercises.map((exerciseName) => {
+      const sets = (exerciseDetails[exerciseName] ?? DEFAULT_SETS)
+        .map((set) => ({ reps: set.reps.trim(), weightKg: set.weightKg.trim() }))
+        .filter((set) => set.reps || set.weightKg)
+
+      return {
+        name: exerciseName,
+        sets
+      }
+    })
+
+    return details
   }
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -129,12 +192,15 @@ export default function CalendarPage() {
 
     const normalizedDistance = distanceKm.trim() ? Number(distanceKm) : undefined
 
+    const savedExerciseDetails = buildExerciseDetails()
+
     const newEntry: ActivityEntry = {
       id: crypto.randomUUID(),
       date,
       type,
       durationMinutes,
       distanceKm: Number.isFinite(normalizedDistance) ? normalizedDistance : undefined,
+      exerciseDetails: savedExerciseDetails,
       exercises: showExerciseSelectors && selectedExercises.length > 0 ? selectedExercises.join(', ') : undefined,
       notes: notes.trim() || undefined,
       createdAt: new Date().toISOString()
@@ -147,6 +213,7 @@ export default function CalendarPage() {
     setDurationMinutes(30)
     setDistanceKm('')
     setSelectedExercises([])
+    setExerciseDetails({})
     setNotes('')
   }
 
@@ -242,6 +309,49 @@ export default function CalendarPage() {
             </label>
           )}
 
+          {showExerciseSelectors && selectedExercises.length > 0 && (
+            <div style={{ gridColumn: '1 / -1' }} className="stack">
+              {selectedExercises.map((exerciseName) => {
+                const sets = exerciseDetails[exerciseName] ?? DEFAULT_SETS
+                return (
+                  <article key={exerciseName} className="set-card">
+                    <p style={{ margin: '0 0 0.5rem 0', fontWeight: 600 }}>{exerciseName}</p>
+                    <div className="set-grid">
+                      <span className="set-header">Serie</span>
+                      <span className="set-header">Reps</span>
+                      <span className="set-header">Peso (kg)</span>
+
+                      {sets.map((set, setIndex) => (
+                        <div className="set-row" key={`${exerciseName}-${setIndex}`}>
+                          <span>{setIndex + 1}</span>
+                          <input
+                            type="number"
+                            min={0}
+                            step={1}
+                            placeholder="10"
+                            value={set.reps}
+                            onChange={(e) => handleSetChange(exerciseName, setIndex, 'reps', e.target.value)}
+                          />
+                          <input
+                            type="number"
+                            min={0}
+                            step={0.5}
+                            placeholder="20"
+                            value={set.weightKg}
+                            onChange={(e) => handleSetChange(exerciseName, setIndex, 'weightKg', e.target.value)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <button type="button" onClick={() => handleAddSet(exerciseName)}>
+                      + Agregar serie
+                    </button>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+
           <label style={{ gridColumn: '1 / -1' }}>
             <span className="label">Notas (opcional)</span>
             <textarea
@@ -303,6 +413,31 @@ export default function CalendarPage() {
                   {entry.distanceKm ? ` · Distancia: ${entry.distanceKm} km` : ''}
                 </p>
                 {entry.exercises && <p style={{ margin: '0.35rem 0 0 0' }}><strong>Ejercicios:</strong> {entry.exercises}</p>}
+                {entry.exerciseDetails && entry.exerciseDetails.length > 0 && (
+                  <details style={{ marginTop: '0.5rem' }}>
+                    <summary style={{ cursor: 'pointer', fontWeight: 600 }}>Ver detalle de series y pesos</summary>
+                    <div className="stack" style={{ marginTop: '0.5rem' }}>
+                      {entry.exerciseDetails.map((exercise) => (
+                        <div key={exercise.name}>
+                          <strong>{exercise.name}</strong>
+                          {exercise.sets.length === 0 ? (
+                            <p style={{ margin: '0.25rem 0 0 0', color: '#64748b' }}>
+                              Sin series cargadas.
+                            </p>
+                          ) : (
+                            <ul style={{ margin: '0.35rem 0 0 1rem', padding: 0 }}>
+                              {exercise.sets.map((set, index) => (
+                                <li key={`${exercise.name}-set-${index}`}>
+                                  Serie {index + 1}: {set.reps || '-'} reps · {set.weightKg || '-'} kg
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </details>
+                )}
                 {entry.notes && <p style={{ margin: '0.35rem 0 0 0' }}><strong>Notas:</strong> {entry.notes}</p>}
               </article>
             ))}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -152,6 +152,31 @@ textarea:focus {
   transform: translateY(-3px);
 }
 
+.set-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: var(--surface-soft);
+}
+
+.set-grid {
+  display: grid;
+  grid-template-columns: 56px 1fr 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.set-row {
+  display: contents;
+}
+
+.set-header {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
 .text-xl { font-size: 1.25rem; }
 .font-bold { font-weight: 700; }
 .p-4 { padding: 1rem; }

--- a/client/src/models/activity.ts
+++ b/client/src/models/activity.ts
@@ -1,11 +1,22 @@
 export type ActivityType = 'running' | 'weights' | 'cycling' | 'walking' | 'other'
 
+export interface ExerciseSet {
+  reps: string
+  weightKg: string
+}
+
+export interface LoggedExercise {
+  name: string
+  sets: ExerciseSet[]
+}
+
 export interface ActivityEntry {
   id: string
   date: string
   type: ActivityType
   durationMinutes: number
   distanceKm?: number
+  exerciseDetails?: LoggedExercise[]
   exercises?: string
   notes?: string
   createdAt: string


### PR DESCRIPTION
### Motivation
- Permitir registrar sets (reps + peso) por ejercicio al guardar una actividad de tipo `Pesas` y poder ver ese detalle desde el historial. 

### Description
- Se añadió el modelo `ExerciseSet` y `LoggedExercise` y se amplió `ActivityEntry` con el campo opcional `exerciseDetails` en `client/src/models/activity.ts`.
- En `client/src/components/Profile/CalendarPage.tsx` se implementó la UI para agregar ejercicios con un conjunto por defecto de 3 series (`DEFAULT_SETS`), editar reps/peso por serie y agregar series adicionales con `+ Agregar serie`, además de construir y guardar `exerciseDetails` al enviar el formulario.
- En el historial se añadió un bloque desplegable (`<details>/<summary>`) que muestra por ejercicio las series y pesos guardados cuando `exerciseDetails` está presente.
- Se agregaron estilos para la grilla de series en `client/src/index.css` y se mantuvo la presencia del campo `exercises` (resumen textual) para compatibilidad con datos existentes.

### Testing
- Ejecuté `cd client && npm run build` y la build completó correctamente (Vite build exitoso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7cbd60948330a692910ca95f8501)